### PR TITLE
Implement CLI entry point (#3)

### DIFF
--- a/src/cocode/__main__.py
+++ b/src/cocode/__main__.py
@@ -4,15 +4,18 @@ import sys
 import typer
 from rich.console import Console
 
+from cocode import __version__
 from cocode.cli.init import init_command
 from cocode.cli.run import run_command
 from cocode.cli.doctor import doctor_command
 from cocode.cli.clean import clean_command
+from cocode.utils.logging import setup_logging
 
 app = typer.Typer(
     name="cocode",
     help="Orchestrate multiple code agents to fix GitHub issues",
     add_completion=True,
+    no_args_is_help=True,
 )
 console = Console()
 
@@ -21,6 +24,31 @@ app.command("init")(init_command)
 app.command("run")(run_command)
 app.command("doctor")(doctor_command)
 app.command("clean")(clean_command)
+
+
+@app.callback()
+def _global_options(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        help="Show the cocode version and exit",
+        is_eager=True,
+    ),
+    log_level: str = typer.Option(
+        "INFO",
+        "--log-level",
+        "-l",
+        help="Set logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
+        case_sensitive=False,
+    ),
+) -> None:
+    """Global options processed before subcommands."""
+    if version:
+        console.print(f"cocode {__version__}")
+        raise typer.Exit()
+    # Initialize logging as early as possible
+    setup_logging(log_level.upper())
 
 
 def main() -> int:


### PR DESCRIPTION
This PR implements the initial CLI entry point using Typer.\n\nChanges:\n- Add global --version flag to print package version\n- Register command groups: init, run, doctor, clean\n- Initialize logging early via --log-level option\n- Enable no-args help for friendlier UX\n\nCloses #3