### PR TITLE
docs: clarify agent auth handled by CLIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,5 +36,6 @@ This repository hosts the `cocode` CLI/TUI for orchestrating multiple code agent
 - Keep diffs focused; update docs or tests alongside code changes.
 
 ## Security & Agent Notes
-- Do not commit secrets. Use environment variables (loaded via `python-dotenv` if present) and GitHub CLI auth (`gh`).
+- Do not commit secrets. Use environment variables if your agent CLI requires them, and authenticate GitHub via `gh`.
+- cocode does not read or manage vendor API keys (OpenAI/Anthropic/etc.). Authentication for AI services is handled entirely by the agent CLIs (e.g., `claude`, `codex`).
 - When adding agents, implement under `src/cocode/agents/` and follow the environment contract in README. Agents must emit the completion marker “cocode ready for check” in their final commit message.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Checks:
 - Dependency versions and paths
 - GitHub authentication status
 - Agent availability (PATH discovery)
-- Environment configuration
+- Note: No vendor API key checks (agents manage auth)
 
 ### Cleanup
 
@@ -162,6 +162,10 @@ Agents signal completion by including `"cocode ready for check"` in their final 
 - Fallback aliases are also checked when applicable (e.g., `claude-code`, `codex-cli`)
 - Run `cocode doctor` to see an "available agents" table with install status and resolved paths
 
+### Agent Authentication
+
+Agent CLIs (e.g., `claude`, `codex`) handle their own authentication and API keys. cocode does not read vendor keys; it only sets `COCODE_*` context variables and launches the agent processes.
+
 ## Project Conventions
 
 If your repository contains a `COCODE.md` file, cocode will read and apply team-specific rules for:
@@ -199,7 +203,7 @@ cocode uses:
 ## Security
 
 - GitHub authentication handled via `gh` CLI
-- Agent API keys read from environment variables
+- Agent authentication is handled by their own CLIs (e.g., `claude`, `codex`). cocode does not read or manage vendor API keys.
 - Basic secret redaction in logs and TUI output
 - No telemetry or remote data collection
 

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -98,7 +98,7 @@ mypy .
 ```
 
 ## Environment Variables
-The app loads environment variables via `python-dotenv` if a `.env` file exists. For local experiments, create `.env` and add keys as needed (no secrets in VCS).
+The app loads environment variables via `python-dotenv` if a `.env` file exists. cocode itself does not read vendor API keys; agent CLIs manage their own authentication. If your agent CLI (e.g., `claude`, `codex`) expects keys from the environment, place them in `.env` locally (never commit secrets).
 
 ## Debugging the TUI
 The TUI is implemented with Textual. During development you can launch the app class directly:

--- a/src/cocode/cli/doctor.py
+++ b/src/cocode/cli/doctor.py
@@ -54,6 +54,8 @@ def doctor_command() -> None:
         agent_table.add_row(info.name, installed, info.path or "-")
     console.print(agent_table)
 
+    # Note: Agents manage their own auth; no API key checks here
+
     # Show GitHub authentication status
     auth = get_auth_status()
     if auth.authenticated:


### PR DESCRIPTION
This PR clarifies that cocode does not read or manage vendor API keys and relies on agent CLIs (e.g., claude, codex) for authentication.\n\nChanges:\n- Update README: note no API key checks in doctor; add Agent Authentication section; clarify Security.\n- Update AGENTS.md: agents manage their own API keys; cocode does not read them.\n- Update docs/development-setup.md:  is only for agent CLIs that require keys.\n\nCloses #9