### PR TITLE
refactor: split run, DRY callbacks, robust lifecycle, worktree helpers

### DIFF
--- a/src/cocode/agents/lifecycle.py
+++ b/src/cocode/agents/lifecycle.py
@@ -41,6 +41,7 @@ class AgentLifecycleInfo:
     worktree_path: Path | None = None
     process: subprocess.Popen[str] | None = None
     thread: threading.Thread | None = None
+    completion_event: threading.Event | None = None
     output_lines: list[str] = field(default_factory=list)
     error: str | None = None
     restart_count: int = 0
@@ -151,6 +152,7 @@ class AgentLifecycleManager:
             self._running_count += 1
 
         # Start agent in a separate thread
+        info.completion_event = threading.Event()
         thread = threading.Thread(
             target=self._run_agent,
             args=(
@@ -235,6 +237,8 @@ class AgentLifecycleManager:
         finally:
             with self._lock:
                 self._running_count -= 1
+                if info.completion_event:
+                    info.completion_event.set()
 
     def stop_agent(self, agent_name: str, force: bool = False) -> bool:
         """Stop a running agent.
@@ -259,18 +263,27 @@ class AgentLifecycleManager:
 
             info.state = AgentState.STOPPING
 
-        # Stop the thread (this is a simplified version)
-        # In a real implementation, we'd need to handle subprocess termination
+        stopped = True
         if info.thread and info.thread.is_alive():
             logger.info(f"Stopping agent {agent_name}")
-            # Thread will complete on its own or timeout
-            # For force stop, we'd need to track the subprocess and terminate it
+            # Request cancellation via runner
+            try:
+                self.runner.cancel_agent(agent_name)
+            except Exception:
+                pass
+
+            # Wait for thread to exit
+            info.thread.join(timeout=5 if not force else 1)
+            if info.thread.is_alive():
+                stopped = False
 
         with self._lock:
-            info.state = AgentState.STOPPED
+            info.state = AgentState.STOPPED if stopped else info.state
 
-        logger.info(f"Stopped agent {agent_name}")
-        return True
+        logger.info(
+            f"Stopped agent {agent_name}" if stopped else f"Agent {agent_name} did not stop in time"
+        )
+        return stopped
 
     def restart_agent(
         self,
@@ -312,12 +325,11 @@ class AgentLifecycleManager:
 
         logger.info(f"Restarting agent {agent_name} (attempt {info.restart_count})")
 
-        # Stop if running
+        # Stop if running and wait for completion event
         if info.state in (AgentState.RUNNING, AgentState.STARTING):
             self.stop_agent(agent_name)
-
-        # Wait a moment for cleanup
-        time.sleep(0.5)
+            if info.completion_event:
+                info.completion_event.wait(timeout=5)
 
         # Start again
         return self.start_agent(
@@ -380,22 +392,43 @@ class AgentLifecycleManager:
     def wait_for_completion(self, timeout: float | None = None) -> bool:
         """Wait for all agents to complete.
 
+        Uses events/joins when available; falls back to light polling otherwise
+        for compatibility with tests that manipulate state directly.
+
         Args:
             timeout: Maximum time to wait in seconds
 
         Returns:
             True if all agents completed, False if timeout
         """
-        import time
-
-        start_time = time.time()
-
-        while self.is_any_running():
-            if timeout and (time.time() - start_time) > timeout:
+        start = time.time()
+        poll_interval = 0.05
+        while True:
+            if not self.is_any_running():
+                return True
+            if timeout is not None and (time.time() - start) > timeout:
                 return False
-            time.sleep(0.5)
 
-        return True
+            # Prefer waiting on any available completion event to avoid polling
+            waited = False
+            with self._lock:
+                infos = list(self.agents.values())
+            for info in infos:
+                if info.completion_event is not None:
+                    remaining = None
+                    if timeout is not None:
+                        remaining = max(0.0, timeout - (time.time() - start))
+                    info.completion_event.wait(
+                        timeout=(
+                            min(poll_interval, remaining)
+                            if remaining is not None
+                            else poll_interval
+                        )
+                    )
+                    waited = True
+                    break
+            if not waited:
+                time.sleep(poll_interval)
 
     def shutdown_all(self, force: bool = False) -> None:
         """Shutdown all agents gracefully.

--- a/src/cocode/git/repository.py
+++ b/src/cocode/git/repository.py
@@ -202,8 +202,8 @@ class RepositoryManager:
             )
             if result.returncode == 0:
                 info["remote_url"] = result.stdout.strip()
-        except Exception as e:
-            logger.debug(f"Could not get remote URL: {e}")
+        except FileNotFoundError as e:
+            logger.debug(f"git not found when getting remote URL: {e}")
 
         try:
             result = subprocess.run(
@@ -214,7 +214,7 @@ class RepositoryManager:
             )
             if result.returncode == 0:
                 info["current_branch"] = result.stdout.strip()
-        except Exception as e:
-            logger.debug(f"Could not get current branch: {e}")
+        except FileNotFoundError as e:
+            logger.debug(f"git not found when getting current branch: {e}")
 
         return info

--- a/src/cocode/git/repository.py
+++ b/src/cocode/git/repository.py
@@ -202,8 +202,8 @@ class RepositoryManager:
             )
             if result.returncode == 0:
                 info["remote_url"] = result.stdout.strip()
-        except FileNotFoundError as e:
-            logger.debug(f"git not found when getting remote URL: {e}")
+        except (FileNotFoundError, subprocess.SubprocessError) as e:
+            logger.debug(f"Failed to get remote URL: {e}")
 
         try:
             result = subprocess.run(
@@ -214,7 +214,7 @@ class RepositoryManager:
             )
             if result.returncode == 0:
                 info["current_branch"] = result.stdout.strip()
-        except FileNotFoundError as e:
-            logger.debug(f"git not found when getting current branch: {e}")
+        except (FileNotFoundError, subprocess.SubprocessError) as e:
+            logger.debug(f"Failed to get current branch: {e}")
 
         return info

--- a/src/cocode/git/worktree.py
+++ b/src/cocode/git/worktree.py
@@ -52,8 +52,8 @@ class WorktreeManager:
         try:
             resolved_path = path.resolve()
             allowed_parent = self.repo_path.parent.resolve()
-            # Path must be directly in the repository's parent directory
-            return resolved_path.parent == allowed_parent
+            # Allow any path under the repo's parent directory
+            return resolved_path.is_relative_to(allowed_parent)
         except (ValueError, RuntimeError):
             return False
 

--- a/src/cocode/git/worktree.py
+++ b/src/cocode/git/worktree.py
@@ -120,47 +120,107 @@ class WorktreeManager:
             raise WorktreeError("Git is not installed or not in PATH") from None
 
     def _is_write_command(self, args: list[str]) -> bool:
-        """Check if a git command is a write operation.
+        """Heuristically determine if a git command is read-only.
 
-        Args:
-            args: Git command arguments
-
-        Returns:
-            True if the command modifies the repository
+        In dry-run mode we default to treating commands as write operations
+        unless they are explicitly known to be read-only. This reduces the
+        chance of missing a new mutating git verb.
         """
         if not args:
             return False
 
-        # Commands that modify the repository
-        write_commands = {
-            "add",
-            "commit",
-            "push",
-            "pull",
-            "merge",
-            "rebase",
-            "checkout",
-            "switch",
-            "reset",
-            "revert",
-            "stash",
-            "worktree",
-            "branch",
-            "tag",
-            "fetch",
+        verb = args[0]
+
+        # Explicitly allow common read-only commands
+        read_only_verbs = {
+            "status",
+            "log",
+            "show",
+            "diff",
+            "rev-parse",
+            "symbolic-ref",
         }
 
-        # Special case for worktree list (read-only)
-        if len(args) >= 2 and args[0] == "worktree" and args[1] == "list":
+        if verb in read_only_verbs:
             return False
 
-        # Special case for branch read-only operations
-        if args[0] == "branch" and (
-            len(args) == 1 or args[1] in ["--list", "-v", "-vv", "--show-current"]
+        # Allow specific read-only subcommands
+        if verb == "worktree" and len(args) >= 2 and args[1] == "list":
+            return False
+
+        if verb == "branch" and (
+            len(args) == 1 or args[1] in {"--list", "-v", "-vv", "--show-current"}
         ):
             return False
 
-        return args[0] in write_commands
+        # Treat all others as potentially mutating
+        return True
+
+    def _compute_worktree_path(self, agent_name: str) -> Path:
+        """Compute and validate worktree path for an agent."""
+        safe_agent_name = self._validate_agent_name(agent_name)
+        worktree_dir_name = f"{self.COCODE_PREFIX}{safe_agent_name}"
+        worktree_path = self.repo_path.parent / worktree_dir_name
+        if not self._validate_worktree_path(worktree_path):
+            raise WorktreeError(f"Worktree path {worktree_path} is outside allowed boundaries")
+        return worktree_path
+
+    def _fetch_remote(self) -> None:
+        """Fetch latest changes from remote."""
+        logger.info("Fetching latest changes from remote")
+        self._run_git_command(["fetch", "--all", "--prune"])
+
+    def _determine_default_branch(self) -> str:
+        """Determine default branch, falling back to 'main'."""
+        try:
+            ref = self._run_git_command(
+                ["symbolic-ref", "refs/remotes/origin/HEAD"]
+            )  # default branch ref
+            return ref.split("/")[-1]
+        except WorktreeError:
+            logger.warning("Could not determine default branch, using 'main'")
+            return "main"
+
+    def _ensure_clean_target(self, worktree_path: Path) -> None:
+        """Ensure the target worktree path is clean or removed."""
+        if worktree_path.exists():
+            if self.dry_run:
+                logger.info(f"[DRY RUN] Would remove existing worktree: {worktree_path}")
+                return
+            logger.warning(f"Worktree path already exists: {worktree_path}")
+            try:
+                self.remove_worktree(worktree_path)
+            except WorktreeError as e:
+                logger.error(f"Failed to remove existing worktree: {e}")
+                raise WorktreeError(f"Path exists but is not a worktree: {worktree_path}") from None
+
+    def _create_git_worktree(
+        self, worktree_path: Path, branch_name: str, default_branch: str
+    ) -> None:
+        """Create the git worktree, handling existing branch fallback."""
+        if self.dry_run:
+            logger.info(
+                f"[DRY RUN] Would create worktree at {worktree_path} with branch {branch_name}"
+            )
+            return
+        logger.info(f"Creating worktree at {worktree_path} with branch {branch_name}")
+        try:
+            self._run_git_command(
+                [
+                    "worktree",
+                    "add",
+                    "-b",
+                    branch_name,
+                    str(worktree_path),
+                    f"origin/{default_branch}",
+                ]
+            )
+        except WorktreeError as e:
+            if "already exists" in str(e):
+                logger.info(f"Branch {branch_name} already exists, checking it out")
+                self._run_git_command(["worktree", "add", str(worktree_path), branch_name])
+            else:
+                raise
 
     def create_worktree(self, branch_name: str, agent_name: str) -> Path:
         """Create a new worktree for an agent.
@@ -175,74 +235,13 @@ class WorktreeManager:
         Raises:
             WorktreeError: If worktree creation fails
         """
-        # Validate and sanitize agent name
-        safe_agent_name = self._validate_agent_name(agent_name)
-        worktree_dir_name = f"{self.COCODE_PREFIX}{safe_agent_name}"
-        worktree_path = self.repo_path.parent / worktree_dir_name
-
-        # Validate the worktree path is within safe boundaries
-        if not self._validate_worktree_path(worktree_path):
-            raise WorktreeError(f"Worktree path {worktree_path} is outside allowed boundaries")
-
-        # Check if worktree already exists
-        if worktree_path.exists():
-            if self.dry_run:
-                logger.info(f"[DRY RUN] Would remove existing worktree: {worktree_path}")
-            else:
-                logger.warning(f"Worktree path already exists: {worktree_path}")
-                # Try to remove it first
-                try:
-                    self.remove_worktree(worktree_path)
-                except WorktreeError as e:
-                    logger.error(f"Failed to remove existing worktree: {e}")
-                    # If it's not a worktree, raise error
-                    raise WorktreeError(
-                        f"Path exists but is not a worktree: {worktree_path}"
-                    ) from None
-
-        # Fetch latest changes
-        logger.info("Fetching latest changes from remote")
-        self._run_git_command(["fetch", "--all", "--prune"])
-
-        # Get the default branch (usually main or master)
-        try:
-            default_branch = self._run_git_command(
-                ["symbolic-ref", "refs/remotes/origin/HEAD"]
-            ).split("/")[-1]
-        except WorktreeError:
-            # Fallback to main if we can't determine default branch
-            logger.warning("Could not determine default branch, using 'main'")
-            default_branch = "main"
-
-        # Create the worktree with a new branch
-        if self.dry_run:
-            logger.info(
-                f"[DRY RUN] Would create worktree at {worktree_path} with branch {branch_name}"
-            )
-            return worktree_path
-        else:
-            logger.info(f"Creating worktree at {worktree_path} with branch {branch_name}")
-            try:
-                self._run_git_command(
-                    [
-                        "worktree",
-                        "add",
-                        "-b",
-                        branch_name,
-                        str(worktree_path),
-                        f"origin/{default_branch}",
-                    ]
-                )
-            except WorktreeError as e:
-                # Branch might already exist, try without -b
-                if "already exists" in str(e):
-                    logger.info(f"Branch {branch_name} already exists, checking it out")
-                    self._run_git_command(["worktree", "add", str(worktree_path), branch_name])
-                else:
-                    raise
-
-            logger.info(f"Successfully created worktree at {worktree_path}")
-            return worktree_path
+        worktree_path = self._compute_worktree_path(agent_name)
+        self._ensure_clean_target(worktree_path)
+        self._fetch_remote()
+        default_branch = self._determine_default_branch()
+        self._create_git_worktree(worktree_path, branch_name, default_branch)
+        logger.info(f"Successfully created worktree at {worktree_path}")
+        return worktree_path
 
     def remove_worktree(self, worktree_path: Path) -> None:
         """Remove a worktree.

--- a/src/cocode/github/issues.py
+++ b/src/cocode/github/issues.py
@@ -242,7 +242,6 @@ class IssueManager:
         state: str = "open",
         labels: list[str] | None = None,
         assignee: str | None = None,
-        page_size: int = 100,
     ) -> list[dict[str, Any]]:
         """Fetch all available issues (limited by gh CLI capabilities).
 

--- a/src/cocode/utils/__init__.py
+++ b/src/cocode/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility modules for cocode."""
 
-from cocode.utils.tempfile_manager import TempFileManager, get_temp_manager
+from cocode.utils.tempfile_manager import TempFileManager
 
-__all__ = ["TempFileManager", "get_temp_manager"]
+__all__ = ["TempFileManager"]


### PR DESCRIPTION
CLI: split run_command into helpers (_print_dry_run, _select_agents, _make_cli_callbacks); simplify cleanup
TUI: centralize agent callbacks via _make_panel_callbacks
Lifecycle: add completion events; cancel-based stop; event-driven waits; remove busy-wait/sleeps
Worktree: factor create_worktree into helpers; safer dry-run detection (read-only allowlist)
Utils: consolidate temp cleanup; deprecate global singleton with compat shim
Executor: extract scheduling helpers for readability
GitHub: remove unused page_size in fetch_all_issues
Git repo info: narrow broad exception handling