### PR TITLE
feat(tui): add header bar with repository and status information

### DIFF
--- a/src/cocode/tui/app.py
+++ b/src/cocode/tui/app.py
@@ -7,12 +7,13 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Horizontal, VerticalScroll
 from textual.reactive import reactive
-from textual.widgets import Footer, Header, Static
+from textual.widgets import Footer, Static
 
 from cocode.agents.base import AgentStatus
 from cocode.agents.lifecycle import AgentLifecycleManager, AgentState
 from cocode.tui.agent_panel import AgentPanel
 from cocode.tui.confirm_quit import ConfirmQuitScreen
+from cocode.tui.header import CocodeHeader
 from cocode.tui.help_overlay import HelpScreen
 from cocode.tui.overview_panel import OverviewPanel
 
@@ -24,13 +25,6 @@ class CocodeApp(App):
     DEFAULT_UPDATE_INTERVAL = 0.5  # seconds, can be made configurable via settings in future
 
     CSS = """
-    .dry-run-indicator {
-        background: $warning;
-        color: $warning-lighten-3;
-        dock: top;
-        height: 1;
-    }
-
     .content {
         height: 1fr;
     }
@@ -193,14 +187,12 @@ class CocodeApp(App):
 
     def compose(self) -> ComposeResult:
         """Compose the TUI layout."""
-        yield Header()
-
-        if self.dry_run:
-            yield Static(
-                "🔍 DRY RUN MODE - No changes will be made",
-                classes="dry-run-indicator",
-                id="dry-run-indicator",
-            )
+        # Use custom header with issue info
+        yield CocodeHeader(
+            issue_number=self.issue_number,
+            issue_title="",  # Will be fetched if needed
+            dry_run=self.dry_run,
+        )
 
         with Container(classes="content"):
             # Top pane with overview

--- a/src/cocode/tui/header.py
+++ b/src/cocode/tui/header.py
@@ -1,0 +1,190 @@
+"""Custom header component for Cocode TUI."""
+
+import subprocess
+
+from textual.reactive import reactive
+from textual.widgets import Static
+
+
+class CocodeHeader(Static):
+    """Custom header displaying repository info, issue details, and auth status."""
+
+    repo_name = reactive("", layout=True)
+    repo_owner = reactive("", layout=True)
+    default_branch = reactive("main", layout=True)
+    issue_number = reactive(0, layout=True)
+    issue_title = reactive("", layout=True)
+    auth_status = reactive(False, layout=True)
+
+    def __init__(
+        self,
+        issue_number: int = 0,
+        issue_title: str = "",
+        dry_run: bool = False,
+        **kwargs: object,
+    ) -> None:
+        """Initialize the header.
+
+        Args:
+            issue_number: GitHub issue number
+            issue_title: Issue title
+            dry_run: Whether in dry run mode
+            **kwargs: Additional arguments for Static
+        """
+        super().__init__(**kwargs)
+        self.issue_number = issue_number
+        self.issue_title = issue_title
+        self.dry_run = dry_run
+        self._fetch_repo_info()
+        self._check_auth_status()
+        self._fetch_issue_title()
+
+    def _fetch_repo_info(self) -> None:
+        """Fetch repository information from git."""
+        try:
+            # Get remote URL and parse repo info
+            result = subprocess.run(
+                ["git", "remote", "get-url", "origin"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode == 0:
+                remote_url = result.stdout.strip()
+                # Parse GitHub URL formats
+                if "github.com" in remote_url:
+                    # Handle both SSH and HTTPS formats
+                    if remote_url.startswith("git@"):
+                        # SSH format: git@github.com:owner/repo.git
+                        parts = remote_url.split(":")[-1]
+                    else:
+                        # HTTPS format: https://github.com/owner/repo.git
+                        url_parts = remote_url.split("/")[-2:]
+                        parts = "/".join(url_parts)
+
+                    # Remove .git suffix if present
+                    parts = parts.removesuffix(".git")
+
+                    # Extract owner and repo
+                    if "/" in parts:
+                        owner, repo = parts.split("/", 1)
+                        self.repo_owner = owner
+                        self.repo_name = repo
+                    else:
+                        self.repo_name = parts
+
+            # Get default branch
+            result = subprocess.run(
+                ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode == 0:
+                # Format: refs/remotes/origin/main
+                self.default_branch = result.stdout.strip().split("/")[-1]
+            else:
+                # Fallback: try to get current branch
+                result = subprocess.run(
+                    ["git", "branch", "--show-current"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    self.default_branch = result.stdout.strip()
+
+        except Exception:
+            # Silently handle errors - use defaults
+            pass
+
+    def _check_auth_status(self) -> None:
+        """Check GitHub CLI authentication status."""
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "status"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.auth_status = result.returncode == 0
+        except FileNotFoundError:
+            # gh CLI not installed
+            self.auth_status = False
+        except Exception:
+            self.auth_status = False
+
+    def _fetch_issue_title(self) -> None:
+        """Fetch issue title from GitHub if not provided."""
+        if self.issue_number and not self.issue_title and self.repo_owner and self.repo_name:
+            try:
+                result = subprocess.run(
+                    [
+                        "gh",
+                        "issue",
+                        "view",
+                        str(self.issue_number),
+                        "--repo",
+                        f"{self.repo_owner}/{self.repo_name}",
+                        "--json",
+                        "title",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if result.returncode == 0:
+                    import json
+
+                    data = json.loads(result.stdout)
+                    self.issue_title = data.get("title", "")
+            except Exception:
+                # Silently handle errors
+                pass
+
+    def render(self) -> str:
+        """Render the header content."""
+        parts = []
+
+        # Repository info
+        if self.repo_owner and self.repo_name:
+            parts.append(f"📦 {self.repo_owner}/{self.repo_name}")
+        elif self.repo_name:
+            parts.append(f"📦 {self.repo_name}")
+        else:
+            parts.append("📦 cocode")
+
+        # Default branch
+        parts.append(f"🌿 {self.default_branch}")
+
+        # Issue info
+        if self.issue_number:
+            if self.issue_title:
+                # Truncate title if too long
+                max_title_len = 40
+                title = self.issue_title[:max_title_len]
+                if len(self.issue_title) > max_title_len:
+                    title += "..."
+                parts.append(f"🎯 #{self.issue_number}: {title}")
+            else:
+                parts.append(f"🎯 Issue #{self.issue_number}")
+
+        # Auth status
+        if self.auth_status:
+            parts.append("🔐 ✓")
+        else:
+            parts.append("🔐 ✗")
+
+        # Dry run indicator
+        if self.dry_run:
+            parts.append("🔍 DRY RUN")
+
+        return " │ ".join(parts)
+
+    def on_mount(self) -> None:
+        """Set up styling when mounted."""
+        self.styles.background = "#004578"  # Primary blue color
+        self.styles.color = "#ffffff"
+        self.styles.padding = (0, 1)
+        self.styles.height = 1
+        self.styles.dock = "top"


### PR DESCRIPTION
## Summary
- Implements a custom header bar component for the TUI that displays key repository and status information
- Replaces the default Textual header with a more informative, context-aware header
- Closes #32

## Changes Made

### New Features
- **Custom Header Component** (`src/cocode/tui/header.py`):
  - Shows repository owner/name from git remote (e.g., `📦 dvelop42/cocode`)
  - Displays default branch name (e.g., `🌿 main`)
  - Shows issue number and fetches title from GitHub API (e.g., `🎯 #32: Add header bar with status`)
  - Indicates GitHub CLI authentication status (`🔐 ✓` or `🔐 ✗`)
  - Shows dry run mode when active (`🔍 DRY RUN`)

### Code Changes
- Created new `CocodeHeader` component that automatically gathers repository information
- Modified `CocodeApp` to use the custom header instead of Textual's default
- Removed redundant dry run indicator since it's now integrated in the header

## Test Plan
- [x] Header displays correctly with all information fields
- [x] Repository information is parsed correctly from git remote
- [x] GitHub authentication status is detected properly
- [x] Issue title is fetched when issue number is provided
- [x] All existing TUI tests pass
- [x] Code passes linting and type checking

## Screenshots
The header displays information in a compact format:
```
📦 dvelop42/cocode │ 🌿 main │ 🎯 #32: Add header bar with status │ 🔐 ✓ │ 🔍 DRY RUN
```

🤖 Generated with [Claude Code](https://claude.ai/code)